### PR TITLE
[UI] improved mobile layout, date and timestamp formats

### DIFF
--- a/app/logic/display_quake.R
+++ b/app/logic/display_quake.R
@@ -16,7 +16,7 @@ display_quake <- function(mag, place, time, depth, id, ns) {
       h3(str_to_title(place)),
       div(
         class = "quake-metadata",
-        p(time),
+        p(format(as.POSIXct(time, tz = "UTC"), tz = "America/New_York", "%Y-%m-%d %H:%M:%S")),
         p(paste(mag, "km"))
       )
     )

--- a/app/logic/make_popup.R
+++ b/app/logic/make_popup.R
@@ -10,6 +10,7 @@ box::use(
 
 #' @export
 make_popup <- function(place, time, mag, mag_type, depth) {
+  time <- format(as.POSIXct(time, tz = "UTC"), tz = "America/New_York", "%Y-%m-%d %H:%M:%S")
   glue::glue(
     "
     <style>

--- a/app/main.R
+++ b/app/main.R
@@ -148,7 +148,8 @@ ui <- function(id) {
     template = "grail-left-sidebar",
     gap = "10px",
     rows = list(
-      default = "auto 1fr 30px"
+      default = "auto 1fr 30px",
+      md = "auto auto 1fr 30px"
     ),
     header = app_header,
     sidebar = app_sidebar,


### PR DESCRIPTION
Issue #32 

## Changes description

* added a definition for the row sizes specifically for smaller screens in `gridPage`
* changed format for timestamp appearing as "2023-03-16T00:56:02.207Z" in [ISO 8601 UTC](https://www.iso.org/iso-8601-date-and-time-format.html) to human readable `%Y-%m-%d %H:%M:%S` UTC